### PR TITLE
tune vagrant provisioning

### DIFF
--- a/01dockerNode/tasks/install_docker.yaml
+++ b/01dockerNode/tasks/install_docker.yaml
@@ -11,3 +11,9 @@
     name: docker.io
     state: present
     update_cache: yes
+
+- name: add Vagrant user to the docker group
+  ansible.builtin.user:
+    name: vagrant
+    groups: docker
+    append: yes

--- a/03dockerPrometheus/files/docker-compose-prometheus.yml
+++ b/03dockerPrometheus/files/docker-compose-prometheus.yml
@@ -2,7 +2,6 @@ version: '3.7'
 
 volumes:
     prometheus_data: {}
-    grafana_data: {}
 
 services:
 

--- a/03dockerPrometheus/tasks/main.yml
+++ b/03dockerPrometheus/tasks/main.yml
@@ -5,14 +5,16 @@
   file:
     path=/docker/prometheus/prometheus
     state=directory
+    mode=777
 
 - name: Create prometheus docker-related data directory
   file:
     path=/docker/prometheus/prometheus_data
     state=directory
+    mode=777
 
 - name: copy prometheus docker file
-  copy: 
+  copy:
     src=files/docker-compose-prometheus.yml
     dest=/docker/prometheus/docker-compose-prometheus.yml
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ vagrant plugin install vagrant-disksize
 Vagrant:17 line can be uncommented in case it is installed
 
 
+
+you probably need to install ansible modules that are not installed in your system by default:
+```sh
+ansible-galaxy collection install -r requirements.yml
+```
+
+there is already generated inventory file, but in case hosts.txt was modified
+you have to execute inventory re-generation command:
+```sh
+ansible-inventory -i hosts.txt --list --yaml --export --output=inventory
+```
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -98,4 +98,11 @@ Vagrant.configure("2") do |config|
     exit 0
   SHELL
   end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.inventory_path = "./inventory"
+    ansible.playbook = "ttask_playbook.yml"
+    ansible.limit = "ttaskL"
+  end
+
 end

--- a/hosts.txt
+++ b/hosts.txt
@@ -1,3 +1,6 @@
+[ttaskLv]
+ansigkastrL ansible_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user=vagrant
+
 [ttaskL]
 ansigkastrL ansible_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_user=vagrant ansible_ssh_private_key_file=ttask_key
 

--- a/inventory
+++ b/inventory
@@ -1,0 +1,27 @@
+all:
+  children:
+    ttaskL:
+      hosts:
+        ansigkastrL:
+          ansible_host: 127.0.0.1
+          ansible_ssh_port: 2222
+          ansible_ssh_private_key_file: ttask_key
+          ansible_ssh_user: vagrant
+    ttaskLv:
+      hosts:
+        ansigkastrL: {}
+    ttaskP:
+      hosts:
+        ansigkastrP:
+          ansible_host: 172.16.10.3
+          ansible_ssh_port: 2222
+          ansible_ssh_private_key_file: ttask_key
+          ansible_ssh_user: vagrant
+    ttaskW:
+      hosts:
+        ansigkastrW:
+          ansible_ssh_host: 172.16.10.88
+          ansible_ssh_port: 2222
+          ansible_ssh_private_key_file: ttask_key
+          ansible_ssh_user: vagrant
+    ungrouped: {}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.docker
+    version: 3.3.2

--- a/ttask_playbook.yml
+++ b/ttask_playbook.yml
@@ -23,9 +23,15 @@
   roles:
     - 02install_node_exporter
 
-- name: Install prometheus
+- name: Setup prometheus container
   hosts: ttaskL
   become: yes
   roles:
     - 03dockerPrometheus
+
+- name: Setup grafana container
+  hosts: ttaskL
+  become: yes
+  roles:
+    - 04dockerGrafana
 


### PR DESCRIPTION
- tune vagrant provisioning (actually added ansible execution through Vagrantfile)
-  add default vagrant user to the docker system group
- tune permissions for prometheus volumes; update README
- added inventory
- added requirements for automagic installation ansible modules if needed
